### PR TITLE
Adding extra logging for matched warnings

### DIFF
--- a/save-core/src/commonNonJsTest/kotlin/org/cqfn/save/core/test/utils/TestUtilsCommon.kt
+++ b/save-core/src/commonNonJsTest/kotlin/org/cqfn/save/core/test/utils/TestUtilsCommon.kt
@@ -66,10 +66,10 @@ fun runTestsWithDiktat(
         if (test.resources.test.name == "ThisShouldAlwaysFailTest.kt") {
             assertEquals(
                 Fail(
-                    "Some warnings were expected but not received:" +
+                    "(MISSING WARNINGS):" +
                             " [Warning(message=[DUMMY_ERROR] this error should not match, line=8, column=1," +
                             " fileName=ThisShouldAlwaysFailTest.kt)]",
-                    "Some warnings were expected but not received (1)"
+                    "(MISSING WARNINGS): (1). (MATCHED WARNINGS): (1)"
                 ), test.status
             )
         } else if (test.resources.test.toString().contains("warn${Path.DIRECTORY_SEPARATOR}chapter2")) {

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/utils/ResultsChecker.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/utils/ResultsChecker.kt
@@ -41,20 +41,20 @@ class ResultsChecker(
 
         return when (missingWarnings.isEmpty() to unexpectedWarnings.isEmpty()) {
             false to true -> Fail(
-                "$EXPECTED_BUT_NOT_RECEIVED $missingWarnings",
-                "$EXPECTED_BUT_NOT_RECEIVED (${missingWarnings.size}). $MATCHED ($expectedWarningsMatchedWithActual)."
+                "$MISSING $missingWarnings",
+                "$MISSING (${missingWarnings.size}). $MATCHED (${expectedWarningsMatchedWithActual.size})"
             )
             false to false -> createFailFromDoubleMiss(missingWarnings, unexpectedWarnings, expectedWarningsMatchedWithActual)
             true to true -> Pass("$ALL_EXPECTED (${expectedWarningsMatchedWithActual.size})")
             true to false -> if (warnPluginConfig.exactWarningsMatch == false) {
                 Pass(
                     "$UNEXPECTED $unexpectedWarnings",
-                    "$UNEXPECTED (${unexpectedWarnings.size}). $MATCHED (${expectedWarningsMatchedWithActual.size})."
+                    "$UNEXPECTED (${unexpectedWarnings.size}). $MATCHED (${expectedWarningsMatchedWithActual.size})"
                 )
             } else {
                 Fail(
                     "$UNEXPECTED $unexpectedWarnings",
-                    "$UNEXPECTED (${unexpectedWarnings.size}). $MATCHED ($expectedWarningsMatchedWithActual)."
+                    "$UNEXPECTED (${unexpectedWarnings.size}). $MATCHED (${expectedWarningsMatchedWithActual.size})"
                 )
             }
             else -> Fail("N/A", "N/A")
@@ -92,16 +92,16 @@ class ResultsChecker(
         unexpectedWarnings: List<Warning>,
         matchedWarnings: List<Warning>
     ) = Fail(
-        "$EXPECTED_BUT_NOT_RECEIVED $missingWarnings. $UNEXPECTED $unexpectedWarnings. $MATCHED $matchedWarnings.",
-        "$EXPECTED_BUT_NOT_RECEIVED (${missingWarnings.size}). " +
+        "$MISSING $missingWarnings. $UNEXPECTED $unexpectedWarnings.",
+        "$MISSING (${missingWarnings.size}). " +
                 "$UNEXPECTED (${unexpectedWarnings.size}). " +
-                "$MATCHED (${matchedWarnings.size})."
+                "$MATCHED (${matchedWarnings.size})"
     )
 
     companion object {
         private const val ALL_EXPECTED = "(ALL WARNINGS MATCHED):"
         private const val MATCHED = "(MATCHED WARNINGS):"
-        private const val EXPECTED_BUT_NOT_RECEIVED = "(MISSING WARNINGS):"
+        private const val MISSING = "(MISSING WARNINGS):"
         private const val UNEXPECTED = "(UNEXPECTED WARNINGS):"
     }
 }

--- a/save-plugins/warn-plugin/src/commonNonJsTest/kotlin/org/cqfn/save/plugin/warn/utils/ComparisonTest.kt
+++ b/save-plugins/warn-plugin/src/commonNonJsTest/kotlin/org/cqfn/save/plugin/warn/utils/ComparisonTest.kt
@@ -54,7 +54,7 @@ class ComparisonTest {
 
         assertTrue(results is Pass, "Actual type of status is ${results::class}")
         assertEquals(
-            "Some warnings were unexpected: ${actualWarningsMap.values.single().dropLast(1)}",
+            "(UNEXPECTED WARNINGS): ${actualWarningsMap.values.single().dropLast(1)}",
             results.message)
     }
 }

--- a/save-plugins/warn-plugin/src/commonTest/kotlin/org/cqfn/save/plugin/warn/WarnPluginTest.kt
+++ b/save-plugins/warn-plugin/src/commonTest/kotlin/org/cqfn/save/plugin/warn/WarnPluginTest.kt
@@ -200,7 +200,7 @@ class WarnPluginTest {
             assertEquals(1, results.size)
             assertTrue(results.single().status is Pass)
             val nameWarn =
-                    "Some warnings were unexpected: [Warning(message=Variable name should be in lowerCamelCase, line=5, column=8, fileName=Test1Test.java)]"
+                    "(UNEXPECTED WARNINGS): [Warning(message=Variable name should be in lowerCamelCase, line=5, column=8, fileName=Test1Test.java)]"
             assertEquals(nameWarn, (results.single().status as Pass).message)
         }
     }


### PR DESCRIPTION
### What's done:
- Now MATCHED warnings are printed even in case of FAIL or PASS