### PR TITLE
Fix performance regression in test resources detection

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -92,8 +92,7 @@ jobs:
             enabledExecutables=debug
       - name: Upload gradle reports
         if: ${{ always() }}
-        # https://github.com/actions/upload-artifact/issues/281
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v2
         with:
           name: gradle-reports-windows-latest
           path: '**/build/reports/'

--- a/README.md
+++ b/README.md
@@ -209,7 +209,6 @@ or using [PMD rules](https://pmd.github.io/). But in all cases a lot of time wil
 ### Build
 The project uses gradle as a build system and can be built with the command `./gradlew build`.
 To compile native artifacts, you will need to install prerequisites as described in Kotlin/Native documentation.
-For example, on Ubuntu you need the following packages: `libncurses5`.
 
 Because of generated code, you will need to run the build once to correctly import project in IDE with resolved imports.
 

--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/config/TestConfig.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/config/TestConfig.kt
@@ -168,18 +168,22 @@ data class TestConfig(
         logDebug("Start merging configs for ${this.location}")
 
         this.parentConfigs().toList().forEach { parentConfig ->
+            logTrace("Processing config ${parentConfig.location} for merging with ${this.location}")
             // return from the function if we stay at the root element of the plugin tree
             val parentalPlugins = parentConfig.pluginConfigs
-            parentalPlugins.forEach { currentConfig ->
-                val childConfigs = this.pluginConfigs.filter { it.type == currentConfig.type }
+            parentalPlugins.forEach { parentalPluginConfig ->
+                val childConfigs = this.pluginConfigs.filter { it.type == parentalPluginConfig.type }
                 if (childConfigs.isEmpty()) {
                     // if we haven't found a plugin from parent in a current list of plugins - we will simply copy it
-                    this.pluginConfigs.add(currentConfig)
+                    this.pluginConfigs.add(parentalPluginConfig)
                 } else {
                     // else, we will merge plugin with a corresponding plugin from a parent config
                     // we expect that there is only one plugin of such type, otherwise we will throw an exception
-                    val mergedConfig = childConfigs.single().mergeWith(currentConfig)
+                    logTrace("Starting actual merge of ${parentalPluginConfig.type} from ${parentConfig.location} into $location")
+                    val mergedConfig = childConfigs.single().mergeWith(parentalPluginConfig)
+                    logTrace("Finished actual merge of ${parentalPluginConfig.type} from ${parentConfig.location} into $location")
                     this.pluginConfigs.set(this.pluginConfigs.indexOf(childConfigs.single()), mergedConfig)
+                    logTrace("Added merged config ${parentalPluginConfig.type} from ${parentConfig.location} into $location")
                 }
             }
         }

--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/utils/ProcessBuilder.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/utils/ProcessBuilder.kt
@@ -120,7 +120,7 @@ class ProcessBuilder(private val useInternalRedirections: Boolean, private val f
         fs.myDeleteRecursively(tmpDir)
         logTrace("Removed temp directory $tmpDir")
         if (stderr.isNotEmpty()) {
-            logDebug("The following errors occurred after executing of `$command`:\t${stderr.joinToString("\t")}")
+            logDebug("stderr of `$command`:\t${stderr.joinToString("\t")}")
         }
         redirectTo?.let {
             fs.write(redirectTo) {

--- a/save-core/src/commonNonJsMain/kotlin/org/cqfn/save/core/Save.kt
+++ b/save-core/src/commonNonJsMain/kotlin/org/cqfn/save/core/Save.kt
@@ -78,10 +78,13 @@ class Save(
             testConfig
                 // fully process this config's configuration sections
                 .processInPlace()
+                .takeIf {
+                    it.isFromEnabledSuite(includeSuites, excludeSuites)
+                }
                 // create plugins and choose only active (with test resources) ones
-                .buildActivePlugins(requestedTests)
-                .takeIf { plugins ->
-                    plugins.isNotEmpty() && plugins.first().isFromEnabledSuite(includeSuites, excludeSuites)
+                ?.buildActivePlugins(requestedTests)
+                ?.takeIf { plugins ->
+                    plugins.isNotEmpty()
                 }
                 ?.also {
                     // configuration has been already validated by this point, and if there are active plugins, then suiteName is not null
@@ -131,8 +134,8 @@ class Save(
         .distinct()
         .joinToString(", ")
 
-    private fun Plugin.isFromEnabledSuite(includeSuites: List<String>, excludeSuites: List<String>): Boolean {
-        val suiteName = testConfig.getGeneralConfig()?.suiteName
+    private fun TestConfig.isFromEnabledSuite(includeSuites: List<String>, excludeSuites: List<String>): Boolean {
+        val suiteName = getGeneralConfig()?.suiteName
         // either no specific includes, or current suite is included
         return (includeSuites.isEmpty() || includeSuites.contains(suiteName)) &&
                 // either no specific excludes, or current suite is not excluded

--- a/save-core/src/commonNonJsMain/kotlin/org/cqfn/save/core/files/ConfigDetector.kt
+++ b/save-core/src/commonNonJsMain/kotlin/org/cqfn/save/core/files/ConfigDetector.kt
@@ -4,6 +4,7 @@ import org.cqfn.save.core.config.TestConfig
 import org.cqfn.save.core.config.isSaveTomlConfig
 import org.cqfn.save.core.logging.logDebug
 import org.cqfn.save.core.logging.logError
+import org.cqfn.save.core.logging.logTrace
 
 import okio.FileSystem
 import okio.Path
@@ -20,6 +21,7 @@ class ConfigDetector(private val fs: FileSystem) {
      * @throws IllegalArgumentException - in case of invalid testConfig file
      */
     fun configFromFile(testConfig: Path): TestConfig {
+        logTrace("Discovering parent configs of $testConfig")
         // testConfig is validated in the beginning and cannot be null
         return discoverConfigWithParents(testConfig)
             // After `discoverConfigWithParents` we successfully created TestConfig instances for all save.toml files
@@ -28,10 +30,12 @@ class ConfigDetector(private val fs: FileSystem) {
             ?.also { config ->
                 // Go down through the file tree and
                 // discover all descendant configs of [config]
+                logTrace("Discovering all descendant `save.toml`s of $testConfig")
                 val descendantConfigLocations = config
                     .directory
                     .findAllFilesMatching { it.isSaveTomlConfig() }
                     .flatten()
+                logTrace("Discovered ${descendantConfigLocations.size} files")
 
                 createTestConfigs(descendantConfigLocations, mutableListOf(config))
             }

--- a/save-core/src/commonNonJsTest/kotlin/org/cqfn/save/core/integration/ClassicWarnTest.kt
+++ b/save-core/src/commonNonJsTest/kotlin/org/cqfn/save/core/integration/ClassicWarnTest.kt
@@ -33,6 +33,7 @@ class ClassicWarnTest {
     }
 
     @Test
+    @Ignore  // https://github.com/diktat-static-analysis/save/issues/333
     fun `execute warn plugin with timeout`() {
         runTestsWithDiktat(
             listOf(


### PR DESCRIPTION
### What's done:
* Check `includedSuites`/`excludedSuites` before checking plugin resources
* Convert sequence to list in`discoverTestFiles` to make checking of missing `testFiles` more performant
* Reduce number of `fx.exists` calls in `Plugin.kt`
* More trace logging
* Disable a test due to #333 
* Revert version of `actions/upload-artifact` to v2, because the bug is fixed

Closes #339