### PR TITLE
Fix of incorrect paths of test files in FixPlugin results

### DIFF
--- a/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
@@ -2,6 +2,7 @@ package org.cqfn.save.plugins.fix
 
 import org.cqfn.save.core.config.TestConfig
 import org.cqfn.save.core.files.createFile
+import org.cqfn.save.core.files.createRelativePathToTheRoot
 import org.cqfn.save.core.files.myDeleteRecursively
 import org.cqfn.save.core.files.readLines
 import org.cqfn.save.core.logging.describe
@@ -27,6 +28,7 @@ import io.github.petertrr.diffutils.patch.Patch
 import io.github.petertrr.diffutils.text.DiffRowGenerator
 import okio.FileSystem
 import okio.Path
+import okio.Path.Companion.toPath
 
 import kotlin.random.Random
 import kotlinx.serialization.Serializable
@@ -243,8 +245,8 @@ class FixPlugin(
         @Serializable(with = PathSerializer::class) val expected: Path
     ) : TestFiles {
         override fun withRelativePaths(root: Path) = copy(
-            test = test.relativeTo(root),
-            expected = expected.relativeTo(root),
+            test = test.createRelativePathToTheRoot(root).toPath(),
+            expected = expected.createRelativePathToTheRoot(root).toPath(),
         )
 
         companion object {


### PR DESCRIPTION
### What's done:
* Restore `relativeTo` from `okio` to our realization 